### PR TITLE
feat: Message, ChatRoom 컴포넌트 구현

### DIFF
--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+import ImageBox from './common/ImageBox';
+import { Message } from './Message';
+import datas from '../utils/data.json';
+import { IMessage } from 'types/message';
+// import { useSelector } from 'react-redux';
+// import { userSelecter } from 'stores/user';
+
+export const ChatRoom = () => {
+  // const user = useSelector(userSelecter);
+
+  return (
+    <ChatRoomBox>
+      {datas.messages.map((message: IMessage) => {
+        const { userName, profileImage, date, content } = message;
+        return (
+          <div key={`${userName}_${content}`}>
+            {/* userName === user */}
+            <MessageBox isMyMessage={false}>
+              <ImageBox imageSrc={profileImage} />
+              <Message myMessage={false}>{content}</Message>
+              <span>{date}</span>
+            </MessageBox>
+          </div>
+        );
+      })}
+      {/* sample */}
+      <div>
+        <MessageBox isMyMessage={true}>
+          <ImageBox imageSrc="https://i.ibb.co/LNw3QCV/image.png" />
+          <Message myMessage={true}>
+            안녕하세요 반갑습니다. 도현입니다. 잘부탁드립니다.
+          </Message>
+          <span>2022-02-10 09:20:35</span>
+        </MessageBox>
+      </div>
+    </ChatRoomBox>
+  );
+};
+
+const ChatRoomBox = styled.div`
+  background-color: transparent;
+  padding: 24px 24px 0;
+  display: flex;
+  flex-direction: column;
+`;
+
+const MessageBox = styled.div<{ isMyMessage: boolean }>`
+  display: flex;
+  flex-direction: ${(props) => (props.isMyMessage ? 'row-reverse' : 'row')};
+  align-items: center;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+  span {
+    width: ${(props) => (props.isMyMessage ? 'auto' : '100%')};
+    font-size: ${({ theme }) => theme.fontSize.smallText};
+    color: ${({ theme }) => theme.colors.gray};
+    margin-top: 10px;
+  }
+`;

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,0 +1,32 @@
+import styled, { css } from 'styled-components';
+
+interface IMyMessageProps {
+  myMessage?: boolean;
+  children: React.ReactNode;
+}
+
+export const Message = ({ myMessage = false, children }: IMyMessageProps) => {
+  return (
+    <MessageContainer isMyMessage={myMessage}>{children}</MessageContainer>
+  );
+};
+
+const MessageContainer = styled.div<{ isMyMessage: boolean }>`
+  ${(props) =>
+    props.isMyMessage
+      ? css`
+          background: ${({ theme }) => theme.colors.myChatBackground};
+          color: ${({ theme }) => theme.colors.white};
+          margin-right: 10px;
+        `
+      : css`
+          background: ${({ theme }) => theme.colors.othersChatBackground};
+          color: ${({ theme }) => theme.colors.black};
+          margin-left: 10px;
+        `}
+  font-size: ${({ theme }) => theme.fontSize.text};
+  padding: 17px 20px;
+  max-width: 75%;
+  border-radius: 6px;
+  line-height: 1.5;
+`;

--- a/src/components/common/ImageBox.tsx
+++ b/src/components/common/ImageBox.tsx
@@ -1,11 +1,13 @@
-import React from "react";
-import styled from "styled-components";
-import { IMessage } from "types/message";
+import React from 'react';
+import styled from 'styled-components';
 
-function ImageBox() {
+interface IImageSrcProps {
+  imageSrc: string;
+}
+function ImageBox({ imageSrc }: IImageSrcProps) {
   return (
     <Container>
-      <img src="https://i.ibb.co/LNw3QCV/image.png" alt="profileImage" />
+      <img src={imageSrc} alt="profileImage" />
     </Container>
   );
 }

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,13 +1,16 @@
-import Footer from "components/Footer";
-import Header from "components/Header";
-import styled from "styled-components";
+import { ChatRoom } from 'components/ChatRoom';
+import Footer from 'components/Footer';
+import Header from 'components/Header';
+import styled from 'styled-components';
 
 function MainPage() {
   return (
     <MainContainer>
       <MainLayout>
         <Header />
-        <Content>this is main{/* 메인 영역  */}</Content>
+        <Content>
+          <ChatRoom />
+        </Content>
         <Footer />
       </MainLayout>
     </MainContainer>
@@ -27,7 +30,6 @@ const MainLayout = styled.div`
 
 const Content = styled.div`
   height: 100%;
-  text-align: center;
   padding-top: 65px;
   background-color: #ffebee;
 `;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -6,7 +6,7 @@ const colors = {
   black: '#000000',
   gray: '#737376',
   myChatBackground: '#ff505f',
-  othersChatBackground: '#ffffff',
+  othersChatBackground: '#f5f5f5',
   button: '#ffe5e8',
   buttonHover: '#ff505f',
   border: '#E6E6E6',

--- a/src/utils/data.json
+++ b/src/utils/data.json
@@ -6,7 +6,7 @@
       "profileImage": "https://i.ibb.co/LNw3QCV/image.png",
       "date": "2022-02-10 09:20:35",
       "content": "저희 미팅은 10시 어떠신가요?",
-      "status": "true"
+      "status": true
     },
     {
       "userId": 2,
@@ -14,7 +14,7 @@
       "profileImage": "https://i.ibb.co/DLRDn7h/image.png",
       "date": "2022-02-10 09:30:48",
       "content": "네 좋습니다. 현재 작업들 모두 취합하겠습니다",
-      "status": "true"
+      "status": true
     },
     {
       "userId": 3,
@@ -22,7 +22,7 @@
       "profileImage": "https://i.ibb.co/Hx4RLy8/image.png",
       "date": "2022-02-10 09:50:21",
       "content": "게더타운에서 뵙겠습니다.",
-      "status": "true"
+      "status": true
     },
     {
       "userId": 1,
@@ -30,7 +30,7 @@
       "profileImage": "https://i.ibb.co/LNw3QCV/image.png",
       "date": "2022-02-10 09:52:19",
       "content": "회의 목록 정리는 wiki에 공유하겠습니다.",
-      "status": "true"
+      "status": true
     },
     {
       "userId": 2,
@@ -38,7 +38,7 @@
       "profileImage": "https://i.ibb.co/DLRDn7h/image.png",
       "date": "2022-02-10 09:53:49",
       "content": "네 감사합니다:)",
-      "status": "true"
+      "status": true
     }
   ]
 }


### PR DESCRIPTION
## 📘 작업 유형

- 신규 기능 추가
- 버그 수정
- 리펙토링

<br/>

## 📑 작업리스트

> 작업한 목록

- Message 컴포넌트 구현
- ChatRoom 컴포넌트 구현
- status 데이터 오류 수정
- ImageBox 컴포넌트 props로 src 입력받도록 수정
- theme에 othersChatBackground 컬러 수정

<br />

## 🚧 특이 사항

> PR을 읽을 때 살펴볼 사항

- Message 컴포넌트에 boolean 값으로  myMessage를 입력받습니다.
- ChatRoom 컴포넌트에서 목데이터를 받아와서 뿌려주는 데 일단 전부 myMessage 값은 false로 해뒀습니다. 나중에 전역에 저장된 user와 목데이터의 userName를 비교해서 넘겨주겠습니다.
- 아직 새 메세지 입력하면 스크롤 아래로 내려가는 기능은 구현 못했습니다.
